### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .nyc_output/
 crash.txt
 fuzz/aflplusplus/out
+/.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,43 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterSSHClientConfig",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterSSHClientConfig", targets: ["TreeSitterSSHClientConfig"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterSSHClientConfig",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.lock",
+                    "Cargo.toml",
+                    "CITATION.cff",
+                    "dev",
+                    "examples",
+                    "fuzz",
+                    "grammar.js",
+                    "LICENSE",
+                    "Makefile",
+                    "package.json",
+                    "package-lock.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                    "test",
+                ],
+                sources: [
+                    "src/parser.c",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterSSHClientConfig/sshclientconfig.h
+++ b/bindings/swift/TreeSitterSSHClientConfig/sshclientconfig.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_SSHCLIENTCONFIG_H_
+#define TREE_SITTER_SSHCLIENTCONFIG_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_sshclientconfig();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_SSHCLIENTCONFIG_H_


### PR DESCRIPTION
This adds Swift bindings and Swift Package Manager (SPM) support. I maintain the tree-sitter Swift binding here https://github.com/chimeHQ/SwiftTreeSitter

Here are some examples of other PRs:

tree-sitter/tree-sitter-go#79
tree-sitter/tree-sitter-c#105
tree-sitter/tree-sitter-haskell#91

These are manually created. They should not ever impact the parser. Changes that require the use of a scanner, which some parsers need, would require an update. The exclude patterns are pretty safe to get out of sync. They can, in some circumstances, generate warnings for Swift users. But, it's really minor.